### PR TITLE
Fix naming: use Case Studies in nav/footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,7 +8,7 @@ const footerLinks = {
   ],
   Company: [
     { label: 'About WandaSystems', href: '/wandasystems-site/company' },
-    { label: 'Portfolio', href: '/wandasystems-site/portfolio' },
+    { label: 'Case Studies', href: '/wandasystems-site/cases' },
     { label: 'Contact', href: '/wandasystems-site/contact' },
   ],
 };

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,7 @@
 ---
 const navItems = [
   { label: 'Services', href: '/wandasystems-site/services' },
-  { label: 'Portfolio', href: '/wandasystems-site/portfolio' },
+  { label: 'Case Studies', href: '/wandasystems-site/cases' },
   { label: 'Company', href: '/wandasystems-site/company' },
   { label: 'Contact', href: '/wandasystems-site/contact' },
 ];

--- a/src/pages/portfolio.astro
+++ b/src/pages/portfolio.astro
@@ -24,17 +24,17 @@ const portfolioItems = [
 ---
 
 <Layout
-  title="Portfolio"
-  description="Selected WandaSystems delivery outcomes across automation, SaaS, and integrations."
+  title="Portfolio (Legacy Alias)"
+  description="Legacy alias page. Canonical case studies are under /cases."
 >
   <section class="pt-20 pb-16" aria-labelledby="portfolio-heading">
     <div class="container-content">
-      <span class="badge mb-4 inline-block">Portfolio</span>
+      <span class="badge mb-4 inline-block">Legacy alias</span>
       <h1 id="portfolio-heading" class="text-heading-1 mb-5 text-text-primary max-w-2xl">
-        Selected project outcomes.
+        This page is deprecated. Use Case Studies.
       </h1>
       <p class="text-body-lg text-text-secondary max-w-xl">
-        Automations, SaaS builds, and integrations — with measurable outcomes for B2B teams.
+        Canonical path: /cases
       </p>
     </div>
   </section>


### PR DESCRIPTION
Replaces Portfolio label with Case Studies and marks /portfolio as legacy alias.