### PR TITLE
Add direct-buy CTA for Data Cleaning Bot on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -81,16 +81,19 @@ const services = [
 
         <!-- CTAs -->
         <div class="flex flex-wrap items-center gap-4">
-          <a href="/wandasystems-site/contact" class="btn-primary">
-            Free initial consultation
+          <a href="https://buy.stripe.com/28E14odfd8u6gPqbkQaVa01" target="_blank" rel="noopener noreferrer" class="btn-primary">
+            Buy Data Cleaning Bot — €29
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
               <path d="M3 7h8M8 4l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </a>
-          <a href="/wandasystems-site/services" class="btn-secondary">
-            View services
+          <a href="/wandasystems-site/services#products-heading" class="btn-secondary">
+            View instant products
           </a>
         </div>
+        <p class="mt-4 max-w-[560px] text-small text-text-muted">
+          Fastest live path right now: direct-buy utility tools with fulfillment email after Stripe confirmation.
+        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Why\nMove homepage from call-first to direct-buy for the strongest currently live revenue path.\n\n## Change\n- primary homepage CTA now goes to Data Cleaning Bot Stripe checkout\n- secondary CTA goes to instant products section\n- note clarifies fast fulfillment path\n\n## Revenue intent\nShorten path from visit to purchase on the cleanest live offer.