### PR TITLE
Add invoice PDF generator to rapid offers

### DIFF
--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -66,6 +66,13 @@ const rapidOffers = [
     desc: 'Fix broken redirects/webhook glue paths, validate endpoint behavior, and add operational fallback notes.',
     deliverable: 'Working route/webhook + verification log + fallback path in <24h.',
   },
+  {
+    id: 'invoice-pdf-generator',
+    title: 'Invoice PDF Generator Bundle (24h)',
+    priceAnchor: '€49 fixed',
+    desc: 'A local Python bundle that generates invoice PDFs from structured JSON input. Good fit when you need simple invoice generation without buying a whole billing platform.',
+    deliverable: 'Python bundle + sample JSON + buyer guide + QA-verified sample PDF in <24h.',
+  },
 ];
 
 const services = [


### PR DESCRIPTION
## Why\nPromote a third real, low-friction offer that is QA-verified and deliverable in under 24h.\n\n## Change\n- add Invoice PDF Generator Bundle to rapid delivery offers\n- keep it honest as manual-fulfillment / scope path, not instant checkout\n\n## Revenue intent\nExpand the active offer core with one additional low-dependency productized offer.