### PR TITLE
⚡ Bolt: Remove render-blocking Google Font @import to improve LCP

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,4 @@
 # Bolt's Journal
+## 2026-03-13 - CSS @import vs HTML preload in Astro
+**Learning:** Astro projects using Tailwind CSS often include a global.css file that inadvertently re-introduces render-blocking @import statements for Google Fonts, even when the main layout (Layout.astro) correctly implements async <link rel="preload">. This creates a hidden sequential request chain (HTML -> CSS -> Font) that hurts LCP.
+**Action:** Always check src/styles/global.css for @import statements when a <link> tag already exists in the head, and remove the @import to enforce parallel font loading.


### PR DESCRIPTION
💡 **What:** 
Removed the render-blocking `@import` statement for the 'Inter' Google Font from `src/styles/global.css`. `src/layouts/Layout.astro` already implements `<link rel="preload">` to fetch it.

🎯 **Why:** 
Having `@import` inside a CSS file creates a hidden sequential request chain: the browser must first download the HTML, then download the CSS, and only then start downloading the web font. This delays font rendering and increases the Largest Contentful Paint (LCP) time. By relying solely on the `<link rel="preload">` in the HTML `head`, we enforce parallel downloading of critical CSS and font resources.

📊 **Impact:** 
Eliminates a sequential network hop (reducing time to first font byte by a full network round-trip). This measurably improves LCP and decreases time-to-interactive for text-heavy pages without sacrificing layout integrity.

🔬 **Measurement:**
Load the preview server and check the Network tab in DevTools: you will observe the Inter font starts downloading concurrently with the `global.css` file rather than waiting for the CSS file to finish parsing.

---
*PR created automatically by Jules for task [5077750041258786807](https://jules.google.com/task/5077750041258786807) started by @wanda-OS-dev*