### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     </script>
   </head>
   <body class="flex min-h-full flex-col bg-brand-black">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:px-4 focus:py-2 focus:bg-brand-gold focus:text-brand-black focus:font-bold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-black focus:ring-brand-white focus:top-2 focus:left-2 rounded-sm">Skip to main content</a>
     <!-- Global atmospheric background -->
     <div class="pointer-events-none fixed inset-0 z-0 wanda-grid-bg opacity-30" aria-hidden="true"></div>
     <div class="pointer-events-none fixed inset-0 z-0" aria-hidden="true">
@@ -118,7 +119,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
       <div class="absolute bottom-1/4 left-0 w-80 h-80 rounded-full blur-[120px] opacity-[0.06]" style="background: radial-gradient(circle, #c9a84c 0%, transparent 70%);"></div>
     </div>
     <Header />
-    <main class="relative z-10 flex-1">
+    <main id="main-content" class="relative z-10 flex-1">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link to the `Layout.astro` file.
🎯 Why: Improves keyboard accessibility by allowing users to bypass repetitive navigation links.
♿ Accessibility: High-impact accessibility improvement for screen reader and keyboard-only users.

This is a micro-UX improvement that adds a small touch of delight and accessibility to the user interface.

---
*PR created automatically by Jules for task [13936117707359932481](https://jules.google.com/task/13936117707359932481) started by @wanda-OS-dev*