### PR TITLE
⚡ Bolt: Lazy load React ContactForm with client:visible

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,5 @@
 # Bolt's Journal
+
+## 2024-03-24 - Astro Directives for Better Island Loading
+**Learning:** React islands (like the ContactForm) initialized with `client:load` cause Astro to immediately load and execute React on initial page load. In forms placed further down the page, this causes unnecessary JS execution and blocks the main thread.
+**Action:** Use `client:visible` for interactive islands located below the fold to lazily load the framework JS only when it scrolls into view, reducing the time-to-interactive (TTI) and initial page load payload.

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -92,7 +92,8 @@ const contactInfo = [
 
         <!-- Right: Form (React Island) -->
         <div class="lg:col-span-2">
-          <ContactForm client:load />
+          {/* ⚡ Bolt Optimization: Changed from client:load to client:visible to lazy-load the React framework and form logic until it enters the viewport. Reduces initial JS payload and speeds up page load. */}
+          <ContactForm client:visible />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 What: Changed the Astro directive for the React `ContactForm` from `client:load` to `client:visible`.
🎯 Why: `client:load` forces the browser to download and execute the React framework and the component's JavaScript immediately upon page load. Since the contact form is located below the fold on the contact page, this work can be safely deferred, reducing the initial JavaScript payload and freeing up the main thread.
📊 Impact: Decreases initial Time-to-Interactive (TTI) and reduces the upfront JS bundle size required to render the initial viewport on the contact page.
🔬 Measurement: Verify using network throttling and Chrome DevTools Performance tab to see that React bundles are only requested when scrolling down to the form.

---
*PR created automatically by Jules for task [18241807553026431862](https://jules.google.com/task/18241807553026431862) started by @wanda-OS-dev*