### PR TITLE
🎨 Palette: Add Skip to Main Content Link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-12 - Accessible Button States
 **Learning:** Icon-only buttons or interactive elements like 'loading' states need proper `aria-live` and `aria-busy` attributes, and the mobile menu needs proper `aria-expanded` on the menu element if it is a dialog.
 **Action:** Add proper `aria` labels to loading spinners and disabled buttons across the app.
+
+## 2026-03-14 - Skip to Content Links
+**Learning:** Skip to content links are essential for keyboard navigation, allowing screen reader and keyboard users to bypass repetitive navigation elements on every page.
+**Action:** Always add a visually hidden 'Skip to main content' link that becomes visible on focus at the top of the body tag, pointing to the main content area.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     </script>
   </head>
   <body class="flex min-h-full flex-col bg-brand-black">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-brand-gold focus:text-brand-black focus:font-semibold focus:rounded-br-lg transition-transform outline-none focus:ring-2 focus:ring-brand-white">Skip to main content</a>
     <!-- Global atmospheric background -->
     <div class="pointer-events-none fixed inset-0 z-0 wanda-grid-bg opacity-30" aria-hidden="true"></div>
     <div class="pointer-events-none fixed inset-0 z-0" aria-hidden="true">
@@ -118,7 +119,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
       <div class="absolute bottom-1/4 left-0 w-80 h-80 rounded-full blur-[120px] opacity-[0.06]" style="background: radial-gradient(circle, #c9a84c 0%, transparent 70%);"></div>
     </div>
     <Header />
-    <main class="relative z-10 flex-1">
+    <main id="main-content" class="relative z-10 flex-1">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
💡 What: Added a visually hidden "Skip to main content" link that becomes visible on keyboard focus at the top of every page.
🎯 Why: Allows screen reader and keyboard-only users to bypass repetitive navigation links (header) and jump straight to the page's primary content, significantly improving efficiency and reducing navigation fatigue.
♿ Accessibility: Improves WCAG compliance for Bypass Blocks (2.4.1) by ensuring keyboard navigability is intuitive and efficient.
📝 Journal: Added the pattern to `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [3835134515706855546](https://jules.google.com/task/3835134515706855546) started by @wanda-OS-dev*