### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to contact form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-14 - [Contact Form Input Length Limits]
+**Vulnerability:** The contact form component (`src/components/ContactForm.tsx`) lacked maximum length constraints on its input fields, leaving it vulnerable to potential denial-of-service (DoS) or memory exhaustion attacks by malicious actors submitting excessively large payloads.
+**Learning:** Even simple, third-party powered forms (like Formspree) need explicit client-side length limits to protect the client application state and prevent abuse.
+**Prevention:** Always set `maxLength` attributes on UI form elements (`<input>`, `<textarea>`) and enforce matching string length checks in the component's internal validation logic.

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -31,13 +31,30 @@ export default function ContactForm() {
 
   const validate = (): boolean => {
     const newErrors: Partial<FormData> = {};
-    if (!data.name.trim()) newErrors.name = 'Name is required';
+    if (!data.name.trim()) {
+      newErrors.name = 'Name is required';
+    } else if (data.name.length > 100) {
+      newErrors.name = 'Name must be less than 100 characters';
+    }
+
     if (!data.email.trim()) {
       newErrors.email = 'Email is required';
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
       newErrors.email = 'Invalid email address';
+    } else if (data.email.length > 100) {
+      newErrors.email = 'Email must be less than 100 characters';
     }
-    if (!data.message.trim()) newErrors.message = 'Message is required';
+
+    if (data.company && data.company.length > 100) {
+      newErrors.company = 'Company name must be less than 100 characters';
+    }
+
+    if (!data.message.trim()) {
+      newErrors.message = 'Message is required';
+    } else if (data.message.length > 2000) {
+      newErrors.message = 'Message must be less than 2000 characters';
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -111,6 +128,7 @@ export default function ContactForm() {
             type="text"
             id="name"
             name="name"
+            maxLength={100}
             value={data.name}
             onChange={handleChange}
             autoComplete="name"
@@ -136,6 +154,7 @@ export default function ContactForm() {
             type="email"
             id="email"
             name="email"
+            maxLength={100}
             value={data.email}
             onChange={handleChange}
             autoComplete="email"
@@ -164,12 +183,22 @@ export default function ContactForm() {
             type="text"
             id="company"
             name="company"
+            maxLength={100}
             value={data.company}
             onChange={handleChange}
             autoComplete="organization"
-            className="w-full rounded-lg border border-border bg-bg-card px-4 py-3 text-small text-text-primary placeholder-text-muted transition-colors focus:border-brand-gold focus:outline-none focus:ring-1 focus:ring-brand-gold"
+            className={`w-full rounded-lg border bg-bg-card px-4 py-3 text-small text-text-primary placeholder-text-muted transition-colors focus:border-brand-gold focus:outline-none focus:ring-1 focus:ring-brand-gold ${
+              errors.company ? 'border-red-500' : 'border-border'
+            }`}
             placeholder="Acme Corp"
+            aria-describedby={errors.company ? 'company-error' : undefined}
+            aria-invalid={!!errors.company}
           />
+          {errors.company && (
+            <p id="company-error" className="mt-1.5 text-xs text-red-400" role="alert" aria-live="polite">
+              {errors.company}
+            </p>
+          )}
         </div>
 
         <div>
@@ -200,6 +229,7 @@ export default function ContactForm() {
         <textarea
           id="message"
           name="message"
+          maxLength={2000}
           value={data.message}
           onChange={handleChange}
           rows={5}


### PR DESCRIPTION
Added input length limits to the Contact form component to mitigate potential DoS or memory exhaustion risks. The `maxLength` attribute is now set on all input fields, and the React component validates string lengths before submitting to the form provider.

---
*PR created automatically by Jules for task [2847146325971776399](https://jules.google.com/task/2847146325971776399) started by @wanda-OS-dev*