### PR TITLE
🎨 Palette: Mobile Navigation Accessibility & Active State Polish

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,22 +30,25 @@ const currentPath = Astro.url.pathname;
 
       <!-- Desktop Nav -->
       <ul class="hidden items-center gap-1 md:flex" role="list">
-        {navItems.map((item) => (
-          <li>
-            <a
-              href={item.href}
-              class:list={[
-                'rounded-lg px-4 py-2 text-small font-medium transition-colors duration-150',
-                currentPath === item.href || currentPath.startsWith(item.href + '/')
-                  ? 'bg-brand-indigo-card text-brand-gold border border-brand-gold/20'
-                  : 'text-text-secondary hover:bg-white/5 hover:text-text-primary',
-              ]}
-              aria-current={currentPath === item.href ? 'page' : undefined}
-            >
-              {item.label}
-            </a>
-          </li>
-        ))}
+        {navItems.map((item) => {
+          const isActive = currentPath === item.href || currentPath === item.href + '/' || currentPath.startsWith(item.href + '/');
+          return (
+            <li>
+              <a
+                href={item.href}
+                class:list={[
+                  'rounded-lg px-4 py-2 text-small font-medium transition-colors duration-150',
+                  isActive
+                    ? 'bg-brand-indigo-card text-brand-gold border border-brand-gold/20'
+                    : 'text-text-secondary hover:bg-white/5 hover:text-text-primary',
+                ]}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {item.label}
+              </a>
+            </li>
+          );
+        })}
       </ul>
 
       <!-- CTA -->
@@ -83,21 +86,25 @@ const currentPath = Astro.url.pathname;
   >
     <div class="container-content py-4">
       <ul class="flex flex-col gap-1" role="list">
-        {navItems.map((item) => (
-          <li>
-            <a
-              href={item.href}
-              class:list={[
-                'block rounded-lg px-4 py-3 text-small font-medium transition-colors',
-                currentPath === item.href
-                  ? 'bg-brand-indigo-card text-brand-gold'
-                  : 'text-text-secondary hover:bg-white/5 hover:text-text-primary',
-              ]}
-            >
-              {item.label}
-            </a>
-          </li>
-        ))}
+        {navItems.map((item) => {
+          const isActive = currentPath === item.href || currentPath === item.href + '/' || currentPath.startsWith(item.href + '/');
+          return (
+            <li>
+              <a
+                href={item.href}
+                class:list={[
+                  'block rounded-lg px-4 py-3 text-small font-medium transition-colors',
+                  isActive
+                    ? 'bg-brand-indigo-card text-brand-gold'
+                    : 'text-text-secondary hover:bg-white/5 hover:text-text-primary',
+                ]}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {item.label}
+              </a>
+            </li>
+          );
+        })}
         <li class="mt-2 pt-2 border-t border-border">
           <a href="/wandasystems-site/contact" class="btn-primary w-full justify-center text-xs">
             Book a call


### PR DESCRIPTION
🎨 Palette: Mobile Navigation Accessibility & Active State Polish

💡 **What:**
- Added `aria-current="page"` to the active links in the mobile navigation menu.
- Refactored the "active link" logic into a single `isActive` variable for both desktop and mobile menus.
- Improved the active state detection to handle child routes and trailing slashes more consistently.

🎯 **Why:**
- Screen reader users rely on `aria-current` to understand which page they are currently on within a navigation list. While this was present on the desktop menu, it was completely missing from the mobile menu.
- Extracting the active state logic ensures that if routing rules change in the future, they only need to be updated in one place, preventing inconsistencies between mobile and desktop views.

📸 **Before/After:**
- Visually, the mobile menu now properly highlights the current page (e.g., when on `/services`, it gets the gold highlight), which was previously missing.
- Accessibly, screen readers now announce the current page correctly.

♿ **Accessibility:**
- Added `aria-current="page"` to active links in the mobile menu, aligning it with WCAG standards and the existing desktop implementation.

---
*PR created automatically by Jules for task [4273420033421738800](https://jules.google.com/task/4273420033421738800) started by @wanda-OS-dev*