### PR TITLE
🎨 Palette: Add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-12 - Accessible Button States
 **Learning:** Icon-only buttons or interactive elements like 'loading' states need proper `aria-live` and `aria-busy` attributes, and the mobile menu needs proper `aria-expanded` on the menu element if it is a dialog.
 **Action:** Add proper `aria` labels to loading spinners and disabled buttons across the app.
+
+## 2024-11-20 - Skip to Main Content Link Accessibility
+**Learning:** Sticky headers and global atmospheric backgrounds can pose an accessibility issue for keyboard and screen reader users, who have to repeatedly tab through the main navigation on every page. Providing a hidden "Skip to main content" link that becomes visible on focus greatly enhances usability. The main tag also needs `tabindex="-1"` and focus removal so it can receive focus programmatically.
+**Action:** Always ensure high-level layouts containing sticky headers include a visible-on-focus skip link.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,9 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     </script>
   </head>
   <body class="flex min-h-full flex-col bg-brand-black">
+    <a href="#main-content" class="absolute -translate-y-full focus:translate-y-0 z-[100] bg-brand-gold text-brand-black px-4 py-2 font-semibold transition-transform duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-white focus-visible:ring-offset-2 focus-visible:ring-offset-brand-black">
+      Skip to main content
+    </a>
     <!-- Global atmospheric background -->
     <div class="pointer-events-none fixed inset-0 z-0 wanda-grid-bg opacity-30" aria-hidden="true"></div>
     <div class="pointer-events-none fixed inset-0 z-0" aria-hidden="true">
@@ -118,7 +121,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
       <div class="absolute bottom-1/4 left-0 w-80 h-80 rounded-full blur-[120px] opacity-[0.06]" style="background: radial-gradient(circle, #c9a84c 0%, transparent 70%);"></div>
     </div>
     <Header />
-    <main class="relative z-10 flex-1">
+    <main id="main-content" class="relative z-10 flex-1" tabindex="-1" style="outline: none;">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link at the start of the document `<body>`.
🎯 Why: To allow keyboard and screen reader users to bypass the sticky header and jump directly to the page's primary content.
📸 Before/After: Screenshots were taken in Playwright during verification showing the link appearing when tabbed to.
♿ Accessibility: Major improvement for users who navigate sequentially (e.g. keyboard users, screen readers) on sites with repetitive navigation blocks.

---
*PR created automatically by Jules for task [105192086863276508](https://jules.google.com/task/105192086863276508) started by @wanda-OS-dev*