### PR TITLE
⚡ Bolt: Lazy hydrate ContactForm with client:visible

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,3 @@
-# Bolt's Journal
+## 2024-05-17 - Astro Hydration Bottlenecks
+**Learning:** In Astro, using `client:load` on heavy React components (like forms) that are below the fold unnecessarily blocks the main thread during initial page load, delaying Time to Interactive (TTI).
+**Action:** Default to `client:visible` for interactive components that are not immediately visible in the viewport, saving `client:load` only for critical above-the-fold interactivity (like navigation menus).

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -92,7 +92,11 @@ const contactInfo = [
 
         <!-- Right: Form (React Island) -->
         <div class="lg:col-span-2">
-          <ContactForm client:load />
+          <!-- ⚡ Bolt: Lazy load the form using client:visible -->
+          <!-- 💡 What: Defer React hydration until the form is in the viewport -->
+          <!-- 🎯 Why: Reduces initial main thread blocking since form is below fold -->
+          <!-- 📊 Impact: Faster Time to Interactive (TTI) for initial page load -->
+          <ContactForm client:visible />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 What: Changed the `<ContactForm client:load />` to `<ContactForm client:visible />` to defer React hydration until the component is in the viewport.
🎯 Why: The contact form is located below the fold on initial page load. Using `client:load` unnecessarily blocks the main thread with JS execution right away.
📊 Impact: Faster Time to Interactive (TTI) and reduced initial main thread blocking time since the heavy form components are only loaded and hydrated when the user scrolls down to them.
🔬 Measurement: Can be verified using Lighthouse or the Chrome DevTools Performance tab by comparing the initial JS execution time and main thread blocking before and after the change.

---
*PR created automatically by Jules for task [10001254638506138810](https://jules.google.com/task/10001254638506138810) started by @wanda-OS-dev*