### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-12 - Accessible Button States
 **Learning:** Icon-only buttons or interactive elements like 'loading' states need proper `aria-live` and `aria-busy` attributes, and the mobile menu needs proper `aria-expanded` on the menu element if it is a dialog.
 **Action:** Add proper `aria` labels to loading spinners and disabled buttons across the app.
+
+## 2026-03-17 - Skip-to-content links
+**Learning:** Adding a "skip to content" link that is only visible when focused (`sr-only focus:not-sr-only`) drastically improves keyboard navigation by letting users bypass repeated navigation elements, without cluttering the visual UI.
+**Action:** When implementing a main layout, always add a visually hidden skip link right after the opening `<body>` tag that targets the main content area (which needs `tabindex="-1"` and `focus:outline-none` so it can receive programmatic focus cleanly).

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,9 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     </script>
   </head>
   <body class="flex min-h-full flex-col bg-brand-black">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-brand-black focus:text-brand-gold focus:outline-none focus:ring-2 focus:ring-brand-gold">
+      Skip to content
+    </a>
     <!-- Global atmospheric background -->
     <div class="pointer-events-none fixed inset-0 z-0 wanda-grid-bg opacity-30" aria-hidden="true"></div>
     <div class="pointer-events-none fixed inset-0 z-0" aria-hidden="true">
@@ -118,7 +121,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
       <div class="absolute bottom-1/4 left-0 w-80 h-80 rounded-full blur-[120px] opacity-[0.06]" style="background: radial-gradient(circle, #c9a84c 0%, transparent 70%);"></div>
     </div>
     <Header />
-    <main class="relative z-10 flex-1">
+    <main id="main-content" tabindex="-1" class="relative z-10 flex-1 focus:outline-none">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
💡 **What:** Added a visually hidden "Skip to content" link at the top of the document that becomes visible on keyboard focus, allowing users to bypass the site header and navigation.
🎯 **Why:** Bypassing repetitive navigation is a WCAG standard for accessibility. It saves keyboard users from having to tab through every navigation link on every single page just to reach the main content.
📸 **Before/After:** (See screenshots of focused state)
♿ **Accessibility:** Added `sr-only` and `focus:not-sr-only` to the link, and configured the `<main>` tag with `tabindex="-1"` and `focus:outline-none` so it can cleanly accept programmatic focus.

---
*PR created automatically by Jules for task [11606372278711295984](https://jules.google.com/task/11606372278711295984) started by @wanda-OS-dev*