### PR TITLE
⚡ Bolt: Remove render-blocking font @import

### DIFF
--- a/preview.log
+++ b/preview.log
@@ -1,0 +1,9 @@
+
+> wandasystems-site@0.1.0 preview
+> astro preview
+
+
+ astro  v4.16.19 ready in 15 ms
+
+┃ Local    http://localhost:4321/wandasystems-site/
+┃ Network  use --host to expose

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+/*
+ * ⚡ Bolt Performance Optimization:
+ * Removed @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+ * from CSS because it blocks rendering. Fonts are loaded via <link> tags in Layout.astro instead,
+ * which supports preloading and doesn't block the initial CSS parse.
+ */
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
💡 **What**: Removed the `@import` rule for the Inter Google Font in `global.css`.
🎯 **Why**: Using `@import` in CSS creates a request chain that blocks rendering. The browser has to wait to download and parse the main CSS file before it even discovers the font stylesheet request. The same font is already correctly included in `Layout.astro` using `<link rel="preload">` and `<link rel="stylesheet">`, which supports concurrent downloading and doesn't block the initial CSS parsing.
📊 **Impact**: Faster First Contentful Paint (FCP) and avoids duplicate network requests for the font stylesheet.
🔬 **Measurement**: Verify in browser DevTools Network tab that the CSS parsing is no longer blocking the font request and that FCP metrics improve. Visual verification confirms the font still loads correctly.

---
*PR created automatically by Jules for task [14456789208995997611](https://jules.google.com/task/14456789208995997611) started by @wanda-OS-dev*