### PR TITLE
🎨 Palette: Add 'Skip to main content' link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-12 - Accessible Button States
 **Learning:** Icon-only buttons or interactive elements like 'loading' states need proper `aria-live` and `aria-busy` attributes, and the mobile menu needs proper `aria-expanded` on the menu element if it is a dialog.
 **Action:** Add proper `aria` labels to loading spinners and disabled buttons across the app.
+
+## 2024-11-20 - Skip-to-content Link for Keyboard Accessibility
+**Learning:** Sites with persistent or lengthy navigation (like the top sticky header here) can be frustrating for keyboard-only users who have to tab through all nav items repeatedly.
+**Action:** Always include a 'Skip to main content' link as the first focusable element in the DOM that becomes visible on focus and jumps straight to the `<main>` content area.

--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1773802970576
+	}
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     </script>
   </head>
   <body class="flex min-h-full flex-col bg-brand-black">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:p-4 focus:bg-brand-black focus:text-brand-gold outline-none">Skip to main content</a>
     <!-- Global atmospheric background -->
     <div class="pointer-events-none fixed inset-0 z-0 wanda-grid-bg opacity-30" aria-hidden="true"></div>
     <div class="pointer-events-none fixed inset-0 z-0" aria-hidden="true">
@@ -118,7 +119,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
       <div class="absolute bottom-1/4 left-0 w-80 h-80 rounded-full blur-[120px] opacity-[0.06]" style="background: radial-gradient(circle, #c9a84c 0%, transparent 70%);"></div>
     </div>
     <Header />
-    <main class="relative z-10 flex-1">
+    <main id="main-content" class="relative z-10 flex-1">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
💡 **What**: Added a "Skip to main content" link at the top of `Layout.astro`.
🎯 **Why**: To improve keyboard and screen reader accessibility, allowing users to bypass the persistent navigation header.
♿ **Accessibility**: Significant improvement for keyboard-only users navigating the site.

---
*PR created automatically by Jules for task [16023679691180719197](https://jules.google.com/task/16023679691180719197) started by @wanda-OS-dev*