### PR TITLE
⚡ Bolt: Remove render-blocking Google Fonts @import

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,1 +1,5 @@
 # Bolt's Journal
+
+## 2026-03-19 - Render-Blocking @import in Global CSS
+**Learning:** Using `@import` inside a main CSS file to load Google Fonts creates a sequential bottleneck. Even if fonts are preloaded in the HTML `<head>`, the CSS parser will halt and wait for the `@import` resolution, negating the async loading benefits and artificially delaying First Contentful Paint (FCP).
+**Action:** Never use `@import` for external fonts in global stylesheets if the fonts are already properly preloaded and linked in the HTML document head.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+/* ⚡ Bolt: Removed @import for Google Fonts */
+/* 💡 What: Removed CSS @import url(...) and instead rely entirely on the <link rel="preload"> setup in Layout.astro. */
+/* 🎯 Why: @import within a CSS file blocks rendering and negates the benefits of async <link> preloading in the HTML head. */
+/* 📊 Impact: Faster First Contentful Paint (FCP) and prevents the CSS parser from halting to fetch external fonts. */
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
💡 **What:** Removed the CSS `@import url(...)` for Google Fonts from `src/styles/global.css`.

🎯 **Why:** Using `@import` within a CSS file creates a sequential render-blocking bottleneck. It forces the browser to download and parse the main CSS file before it even discovers that it needs to fetch the font, completely negating the async `<link rel="preload">` setup already present in the HTML `<head>`.

📊 **Impact:** Faster First Contentful Paint (FCP). The browser can now discover and load fonts asynchronously right away without pausing CSS parsing.

🔬 **Measurement:** Verify by running Lighthouse or checking the Network tab timeline for parallel resource loading rather than sequential blocking.

---
*PR created automatically by Jules for task [13818148322420326431](https://jules.google.com/task/13818148322420326431) started by @wanda-OS-dev*