### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-03-12 - Accessible Button States
 **Learning:** Icon-only buttons or interactive elements like 'loading' states need proper `aria-live` and `aria-busy` attributes, and the mobile menu needs proper `aria-expanded` on the menu element if it is a dialog.
 **Action:** Add proper `aria` labels to loading spinners and disabled buttons across the app.
+## 2026-03-19 - Skip Links in Astro Layouts
+**Learning:** When dealing with Astro and sites with persistent and sticky headers, adding a visually hidden skip-to-content link right after the `<body>` opening tag is crucial for keyboard navigation and screen reader users. It ensures they don't have to tab through the navigation menu on every page load.
+**Action:** Add a `<a href="#main-content" class="sr-only focus:not-sr-only...">Skip to content</a>` and apply `id="main-content" tabindex="-1"` to the `<main>` element in layout templates.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,12 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     </script>
   </head>
   <body class="flex min-h-full flex-col bg-brand-black">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 z-[100] btn-primary"
+    >
+      Skip to content
+    </a>
     <!-- Global atmospheric background -->
     <div class="pointer-events-none fixed inset-0 z-0 wanda-grid-bg opacity-30" aria-hidden="true"></div>
     <div class="pointer-events-none fixed inset-0 z-0" aria-hidden="true">
@@ -118,7 +124,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
       <div class="absolute bottom-1/4 left-0 w-80 h-80 rounded-full blur-[120px] opacity-[0.06]" style="background: radial-gradient(circle, #c9a84c 0%, transparent 70%);"></div>
     </div>
     <Header />
-    <main class="relative z-10 flex-1">
+    <main id="main-content" tabindex="-1" class="relative z-10 flex-1">
       <slot />
     </main>
     <Footer />


### PR DESCRIPTION
💡 What: Added a "Skip to content" link at the top of the body in `Layout.astro` that jumps focus to the `<main>` element.
🎯 Why: Sites with persistent headers force keyboard and screen reader users to tab through the entire navigation menu on every page load. A skip link is a critical UX/accessibility improvement that lets them bypass this and go straight to the content.
📸 Before/After: Visual changes only appear on keyboard focus (the link becomes visible in the top left).
♿ Accessibility: Improves WCAG compliance (Bypass Blocks) by providing a mechanism to bypass blocks of content that are repeated on multiple Web pages. Includes adding `id="main-content"` and `tabindex="-1"` to the `<main>` element to ensure it can programmatically receive focus.

---
*PR created automatically by Jules for task [15615495533164703038](https://jules.google.com/task/15615495533164703038) started by @wanda-OS-dev*