### PR TITLE
🛡️ Sentinel: [HIGH] Add Content-Security-Policy header to deployment configs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-03-19 - Missing Content Security Policy
+**Vulnerability:** The application was missing a Content-Security-Policy header in its deployment configurations (`vercel.json` and `netlify.toml`).
+**Learning:** Even static/Jamstack applications need CSP to mitigate XSS and data injection attacks. The policy must account for external services like Google Fonts and Formspree.
+**Prevention:** Ensure deployment configuration files include a restrictive CSP that only allows necessary external domains and inline scripts/styles required by the framework (Astro).

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,4 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), browsing-topics=()"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://formspree.io;"

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,10 @@
         {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=(), browsing-topics=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://formspree.io;"
         }
       ]
     }


### PR DESCRIPTION
This PR adds a `Content-Security-Policy` header to the deployment configuration files (`vercel.json` and `netlify.toml`).

This is a security enhancement to mitigate the risk of Cross-Site Scripting (XSS) and other data injection attacks. The CSP is configured to allow resources necessary for the application to function correctly, such as Google Fonts and Formspree submissions, while restricting other unknown sources.

A journal entry has also been added to `.jules/sentinel.md` to document this security learning.

---
*PR created automatically by Jules for task [8228394566631327220](https://jules.google.com/task/8228394566631327220) started by @wanda-OS-dev*