### PR TITLE
⚡ Bolt: Add preconnect for critical external domains

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -71,6 +71,12 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
     <!-- Preconnect for performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- ⚡ Bolt: Added preconnect for Formspree and Stripe -->
+    <!-- 💡 What: Establishing early network connections to critical third-party domains. -->
+    <!-- 🎯 Why: DNS/TCP/TLS handshakes take time. Preconnecting reduces latency when the user clicks a checkout link or submits the form. -->
+    <!-- 📊 Impact: Faster time-to-interactive for form submissions and checkout navigations. -->
+    <link rel="preconnect" href="https://buy.stripe.com" crossorigin />
+    <link rel="preconnect" href="https://formspree.io" crossorigin />
     <link
       rel="preload"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"


### PR DESCRIPTION
💡 What: Added early connection hints for Stripe and Formspree URLs in the application shell.
🎯 Why: Establish early network TLS/DNS handshakes to external services.
📊 Impact: Reduced latency when users initiate checkouts via Stripe links or submit the React Formspree contact form.
🔬 Measurement: Verify tags exist in <head> and check network waterfall for earlier DNS resolution.

---
*PR created automatically by Jules for task [16671038485622151245](https://jules.google.com/task/16671038485622151245) started by @wanda-OS-dev*