### PR TITLE
🎨 Palette: Improve accessibility for external links and logo navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,7 +16,12 @@ const currentPath = Astro.url.pathname;
   <div class="container-content">
     <nav class="flex h-16 items-center justify-between" role="navigation" aria-label="Main navigation">
       <!-- Logo -->
-      <a href="/wandasystems-site/" class="flex items-center gap-2.5 no-underline group" aria-label="WandaSystems Home">
+      <a
+        href="/wandasystems-site/"
+        class="flex items-center gap-2.5 no-underline group"
+        aria-label="WandaSystems Home"
+        aria-current={currentPath === '/wandasystems-site/' || currentPath === '/wandasystems-site' ? 'page' : undefined}
+      >
         <div class="relative">
           <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
             <rect width="28" height="28" rx="6" fill="#111111" stroke="rgba(201,168,76,0.4)" stroke-width="1"/>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -83,6 +83,7 @@ const services = [
         <div class="flex flex-wrap items-center gap-4">
           <a href="https://buy.stripe.com/28E14odfd8u6gPqbkQaVa01" target="_blank" rel="noopener noreferrer" class="btn-primary">
             Buy Data Cleaning Bot — €29
+            <span class="sr-only">(opens in a new tab)</span>
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
               <path d="M3 7h8M8 4l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -213,6 +213,7 @@ const services = [
                 style={p.primary ? '' : 'display: flex; align-items: center;'}
               >
                 {p.cta}
+                <span class="sr-only">(opens in a new tab)</span>
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true" class="ml-2">
                   <path d="M3 7h8M8 4l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>


### PR DESCRIPTION
### 💡 What: 
Added two micro-UX/accessibility enhancements: 
1. `aria-current="page"` semantics to the main logo link when the user is on the homepage.
2. A visually hidden (but screen-reader accessible) warning: `(opens in a new tab)` for external Stripe checkout buttons.

### 🎯 Why: 
- Providing context that a link points to the "current page" helps users relying on assistive technologies understand their location within the site's navigation.
- Alerting screen reader users that a link will open in a new tab (`target="_blank"`) prevents disorientation and unexpected loss of navigation context.

### ♿ Accessibility:
- Used `aria-current="page"` correctly on the navigation link to the homepage.
- Leveraged the existing Tailwind `sr-only` utility class to ensure the new tab warning text is visually hidden but read aloud by screen readers.

---
*PR created automatically by Jules for task [11926232063847223454](https://jules.google.com/task/11926232063847223454) started by @wanda-OS-dev*