### PR TITLE
🧹 [Code Health] Extract duplicated SVG logo into reusable Logo component

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import Logo from "./Logo.astro";
+
 const footerLinks = {
   Services: [
     { label: 'AI Automations', href: '/wandasystems-site/services#automation' },
@@ -24,11 +26,7 @@ const footerLinks = {
       <!-- Brand -->
       <div class="lg:col-span-2">
         <a href="/wandasystems-site/" class="flex items-center gap-2.5 no-underline mb-4 group" aria-label="WandaSystems">
-          <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
-            <rect width="28" height="28" rx="6" fill="#111111" stroke="rgba(201,168,76,0.4)" stroke-width="1"/>
-            <path d="M5 8L9 21L14 15L19 21L23 8" stroke="#f5f5f0" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M7.5 8L9 11.5L14 15L19 11.5L20.5 8" stroke="#c9a84c" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" opacity="0.45"/>
-          </svg>
+          <Logo />
           <span class="text-sm font-semibold text-text-primary group-hover:text-brand-gold transition-colors">WandaSystems</span>
         </a>
         <p class="max-w-xs text-small text-text-secondary leading-relaxed">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,5 @@
 ---
+import Logo from "./Logo.astro";
 const navItems = [
   { label: 'Services', href: '/wandasystems-site/services' },
   { label: 'Case Studies', href: '/wandasystems-site/cases' },
@@ -23,11 +24,7 @@ const currentPath = Astro.url.pathname;
         aria-current={currentPath === '/wandasystems-site/' || currentPath === '/wandasystems-site' ? 'page' : undefined}
       >
         <div class="relative">
-          <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
-            <rect width="28" height="28" rx="6" fill="#111111" stroke="rgba(201,168,76,0.4)" stroke-width="1"/>
-            <path d="M5 8L9 21L14 15L19 21L23 8" stroke="#f5f5f0" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M7.5 8L9 11.5L14 15L19 11.5L20.5 8" stroke="#c9a84c" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" opacity="0.45"/>
-          </svg>
+          <Logo />
           <div class="absolute inset-0 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-300" style="box-shadow: 0 0 12px rgba(201,168,76,0.4);"></div>
         </div>
         <span class="text-sm font-semibold tracking-tight text-text-primary group-hover:text-brand-gold transition-colors duration-150">WandaSystems</span>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,7 @@
+---
+---
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
+  <rect width="28" height="28" rx="6" fill="#111111" stroke="rgba(201,168,76,0.4)" stroke-width="1"/>
+  <path d="M5 8L9 21L14 15L19 21L23 8" stroke="#f5f5f0" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7.5 8L9 11.5L14 15L19 11.5L20.5 8" stroke="#c9a84c" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" opacity="0.45"/>
+</svg>


### PR DESCRIPTION
🎯 **What:** The exact same `<svg>` code was used for the logo in `Header.astro` and `Footer.astro`. This PR extracts this duplicated code into a new, reusable `<Logo />` component (`src/components/Logo.astro`).

💡 **Why:** Single-sourcing the logo improves maintainability and makes future updates easier. A change to the logo's paths, colors, or sizes will now only need to be made in one place.

✅ **Verification:** Verified the code builds successfully locally with `npm run build`. Wrote a Playwright script to navigate the local dev server and visually verified (with screenshot and video recording) that the logo still renders accurately in both the header and footer.

✨ **Result:** Reduced duplication in `Header.astro` and `Footer.astro`. The codebase is cleaner and DRY-er with no functional or visual regressions.

---
*PR created automatically by Jules for task [3908494894752562168](https://jules.google.com/task/3908494894752562168) started by @wanda-OS-dev*