### PR TITLE
🔒 Fix XSS via set:html in JSON-LD Script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy header in its deployment configurations (`vercel.json` and `netlify.toml`).
 **Learning:** Even static/Jamstack applications need CSP to mitigate XSS and data injection attacks. The policy must account for external services like Google Fonts and Formspree.
 **Prevention:** Ensure deployment configuration files include a restrictive CSP that only allows necessary external domains and inline scripts/styles required by the framework (Astro).
+## 2026-03-21 - XSS Fix in JSON-LD
+- **What:** Escaped angle brackets in JSON-LD structured data within Layout.astro.
+- **Risk:** High. Untrusted 'description' prop could inject a </script> tag, allowing arbitrary JS execution.
+- **Solution:** Applied .replace(/</g, '\\u003c') to JSON.stringify output.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,7 +66,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
         "contactType": "sales",
         "email": "wanda.devops@gmail.com"
       }
-    })} />
+    }).replace(/</g, '\\u003c')} />
 
     <!-- Preconnect for performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Applied `.replace(/</g, '\\u003c')` to the `JSON.stringify` output within the JSON-LD script tag in `src/layouts/Layout.astro`.

⚠️ **Risk:** The potential impact if left unfixed
High. An attacker could provide a `description` prop containing `</script><script>alert(1)</script>`, which would break out of the JSON-LD script block and execute arbitrary JavaScript in the user's browser.

🛡️ **Solution:** How the fix addresses the vulnerability
By escaping `<` to `\u003c`, the HTML parser will no longer see a closing `</script>` tag, effectively neutralizing the XSS vector while maintaining valid JSON-LD that can be correctly parsed by search engines and other tools.

---
*PR created automatically by Jules for task [5427408424063189393](https://jules.google.com/task/5427408424063189393) started by @wanda-OS-dev*