### PR TITLE
🎨 Palette: Contextual link labels and intent passing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-03-19 - Skip Links in Astro Layouts
 **Learning:** When dealing with Astro and sites with persistent and sticky headers, adding a visually hidden skip-to-content link right after the `<body>` opening tag is crucial for keyboard navigation and screen reader users. It ensures they don't have to tab through the navigation menu on every page load.
 **Action:** Add a `<a href="#main-content" class="sr-only focus:not-sr-only...">Skip to content</a>` and apply `id="main-content" tabindex="-1"` to the `<main>` element in layout templates.
+## 2024-03-20 - Contextual Link Labels & Intent Passing
+**Learning:** Generic call-to-action links (like "Request scope") fail WCAG criteria for link purpose in context. Furthermore, dropping users onto a generic form after they clicked a specific service creates friction.
+**Action:** Added `sr-only` context spans to generic links, and implemented URL query parameter parsing in the Contact form to pre-fill the selected service, bridging the user's intent from the referring page.

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 type FormState = 'idle' | 'loading' | 'success' | 'error';
 
@@ -28,6 +28,15 @@ export default function ContactForm() {
     message: '',
   });
   const [errors, setErrors] = useState<Partial<FormData>>({});
+
+  useEffect(() => {
+    // Check if there is a 'service' query parameter to pre-fill intent
+    const params = new URLSearchParams(window.location.search);
+    const serviceParam = params.get('service');
+    if (serviceParam && serviceOptions.some((opt) => opt.value === serviceParam)) {
+      setData((prev) => ({ ...prev, service: serviceParam }));
+    }
+  }, []);
 
   const validate = (): boolean => {
     const newErrors: Partial<FormData> = {};

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -311,7 +311,9 @@ const pausedProducts = products.filter((p) => !p.primary);
             <p class="text-small text-brand-gold mb-3">{o.priceAnchor}</p>
             <p class="text-body text-text-secondary mb-4">{o.desc}</p>
             <p class="text-xs text-text-muted mb-4">{o.deliverable}</p>
-            <a href={contactHref} class="btn-secondary inline-flex">Request scope</a>
+            <a href={`${contactHref}?service=other`} class="btn-secondary inline-flex">
+              Request scope<span class="sr-only"> for {o.title}</span>
+            </a>
           </article>
         ))}
       </div>
@@ -342,8 +344,8 @@ const pausedProducts = products.filter((p) => !p.primary);
               <h3 class="text-heading-3 mb-2 text-text-primary">{s.title}</h3>
               <p class="text-small text-brand-gold mb-4">{s.priceAnchor}</p>
               <p class="text-body text-text-secondary mb-6">{s.desc}</p>
-              <a href={contactHref} class="btn-secondary inline-flex items-center gap-2">
-                Request project scope
+              <a href={`${contactHref}?service=${s.id}`} class="btn-secondary inline-flex items-center gap-2">
+                Request project scope<span class="sr-only"> for {s.title}</span>
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
                   <path d="M3 7h8M8 4l3 3-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>


### PR DESCRIPTION
💡 What: Added screen-reader-only (`sr-only`) context to generic generic call-to-action links (like "Request scope") and connected intent by appending URL query parameters (`?service=...`) which are parsed on the contact form to pre-select the appropriate service option.
🎯 Why: Generic links fail WCAG criteria for link purpose in context. Furthermore, dropping users onto a generic form after they clicked a specific service creates friction. By passing the intent through the URL, we bridge the user's intent from the referring page and improve flow.
📸 Before/After: Visual changes shown in attached verification screenshot.
♿ Accessibility: Screen reader users will now hear "Request scope for [Service Name]" instead of just "Request scope".

---
*PR created automatically by Jules for task [3974915851528400854](https://jules.google.com/task/3974915851528400854) started by @wanda-OS-dev*