### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in JSON-LD Script Tag

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,8 @@
 **Vulnerability:** The application was missing a Content-Security-Policy header in its deployment configurations (`vercel.json` and `netlify.toml`).
 **Learning:** Even static/Jamstack applications need CSP to mitigate XSS and data injection attacks. The policy must account for external services like Google Fonts and Formspree.
 **Prevention:** Ensure deployment configuration files include a restrictive CSP that only allows necessary external domains and inline scripts/styles required by the framework (Astro).
+
+## 2026-03-22 - [XSS in JSON-LD Script Tag]
+**Vulnerability:** XSS vulnerability through unescaped `<` characters in JSON.stringify() output used within a `<script type="application/ld+json">` tag.
+**Learning:** `JSON.stringify()` does not escape HTML entities. If user input or props (like description) contain `</script>`, it can break out of the `<script>` tag and execute arbitrary JavaScript.
+**Prevention:** Always escape angle brackets in stringified JSON within script tags using `.replace(/</g, '\\u003c')`.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,7 +66,7 @@ const canonicalURL = canonical ?? new URL(Astro.url.pathname, siteBase);
         "contactType": "sales",
         "email": "wanda.devops@gmail.com"
       }
-    })} />
+    }).replace(/</g, '\\u003c')} />
 
     <!-- Preconnect for performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS Vulnerability in JSON-LD Injection

🚨 Severity: HIGH
💡 Vulnerability: The JSON-LD injection in `src/layouts/Layout.astro` used `JSON.stringify(data)` directly inside a `<script type="application/ld+json">` tag without escaping HTML entities. If input properties like `description` contained `</script>`, it could allow an attacker to prematurely close the script tag and execute arbitrary JavaScript.
🎯 Impact: This could allow a Cross-Site Scripting (XSS) attack if user-controlled input or compromised external data is injected into these variables.
🔧 Fix: Added `.replace(/</g, '\\u003c')` to properly escape angle brackets in the JSON-LD string. This ensures the browser safely parses the content as JSON without executing embedded scripts, while remaining valid JSON for SEO parsers.
✅ Verification: Ran `npm run build` locally and verified the site successfully compiles with the escaped script tags, ensuring no regressions.

Also updated `.jules/sentinel.md` to record this security learning for the codebase.

---
*PR created automatically by Jules for task [9666936092492916115](https://jules.google.com/task/9666936092492916115) started by @wanda-OS-dev*